### PR TITLE
Allow to filter OSGi bundles from bundle status check

### DIFF
--- a/AEMManager/PreferencesDialog.Designer.cs
+++ b/AEMManager/PreferencesDialog.Designer.cs
@@ -24,71 +24,112 @@ namespace AEMManager {
     /// </summary>
     private void InitializeComponent() {
       this.cmdCancel = new System.Windows.Forms.Button();
-      this.cmOK = new System.Windows.Forms.Button();
+      this.cmdOK = new System.Windows.Forms.Button();
       this.txtLogViewer = new System.Windows.Forms.TextBox();
       this.lblLogViewer = new System.Windows.Forms.Label();
-      this.label1 = new System.Windows.Forms.Label();
+      this.lblLogViewerDescription = new System.Windows.Forms.Label();
+      this.txtBundleFilter = new System.Windows.Forms.TextBox();
+      this.lblBundleFilter = new System.Windows.Forms.Label();
+      this.lblBundleFilterDescription = new System.Windows.Forms.Label();
       this.SuspendLayout();
-      //
+      // 
       // cmdCancel
-      //
+      // 
       this.cmdCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-      this.cmdCancel.Location = new System.Drawing.Point(516, 40);
+      this.cmdCancel.Location = new System.Drawing.Point(774, 62);
+      this.cmdCancel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
       this.cmdCancel.Name = "cmdCancel";
-      this.cmdCancel.Size = new System.Drawing.Size(88, 23);
+      this.cmdCancel.Size = new System.Drawing.Size(132, 35);
       this.cmdCancel.TabIndex = 3;
       this.cmdCancel.Text = "Cancel";
       this.cmdCancel.UseVisualStyleBackColor = true;
       this.cmdCancel.Click += new System.EventHandler(this.cmdCancel_Click);
-      //
-      // cmOK
-      //
-      this.cmOK.Location = new System.Drawing.Point(516, 8);
-      this.cmOK.Name = "cmOK";
-      this.cmOK.Size = new System.Drawing.Size(88, 24);
-      this.cmOK.TabIndex = 2;
-      this.cmOK.Text = "OK";
-      this.cmOK.UseVisualStyleBackColor = true;
-      this.cmOK.Click += new System.EventHandler(this.cmOK_Click);
-      //
+      // 
+      // cmdOK
+      // 
+      this.cmdOK.Location = new System.Drawing.Point(774, 12);
+      this.cmdOK.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.cmdOK.Name = "cmdOK";
+      this.cmdOK.Size = new System.Drawing.Size(132, 37);
+      this.cmdOK.TabIndex = 2;
+      this.cmdOK.Text = "OK";
+      this.cmdOK.UseVisualStyleBackColor = true;
+      this.cmdOK.Click += new System.EventHandler(this.cmdOK_Click);
+      // 
       // txtLogViewer
-      //
-      this.txtLogViewer.Location = new System.Drawing.Point(84, 12);
+      // 
+      this.txtLogViewer.Location = new System.Drawing.Point(126, 18);
+      this.txtLogViewer.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
       this.txtLogViewer.Name = "txtLogViewer";
-      this.txtLogViewer.Size = new System.Drawing.Size(404, 20);
+      this.txtLogViewer.Size = new System.Drawing.Size(604, 26);
       this.txtLogViewer.TabIndex = 1;
-      //
+      // 
       // lblLogViewer
-      //
+      // 
       this.lblLogViewer.AutoSize = true;
-      this.lblLogViewer.Location = new System.Drawing.Point(12, 16);
+      this.lblLogViewer.Location = new System.Drawing.Point(18, 21);
+      this.lblLogViewer.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
       this.lblLogViewer.Name = "lblLogViewer";
-      this.lblLogViewer.Size = new System.Drawing.Size(60, 13);
+      this.lblLogViewer.Size = new System.Drawing.Size(88, 20);
       this.lblLogViewer.TabIndex = 0;
       this.lblLogViewer.Text = "Log Viewer";
-      //
-      // label1
-      //
-      this.label1.AutoSize = true;
-      this.label1.Location = new System.Drawing.Point(81, 40);
-      this.label1.Name = "label1";
-      this.label1.Size = new System.Drawing.Size(284, 13);
-      this.label1.TabIndex = 4;
-      this.label1.Text = "Log filename is automatically attached to the command line";
-      //
+      // 
+      // lblLogViewerDescription
+      // 
+      this.lblLogViewerDescription.AutoSize = true;
+      this.lblLogViewerDescription.Location = new System.Drawing.Point(122, 59);
+      this.lblLogViewerDescription.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblLogViewerDescription.Name = "lblLogViewerDescription";
+      this.lblLogViewerDescription.Size = new System.Drawing.Size(425, 20);
+      this.lblLogViewerDescription.TabIndex = 2;
+      this.lblLogViewerDescription.Text = "Log filename is automatically attached to the command line";
+      // 
+      // txtBundleFilter
+      // 
+      this.txtBundleFilter.Location = new System.Drawing.Point(126, 110);
+      this.txtBundleFilter.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+      this.txtBundleFilter.Multiline = true;
+      this.txtBundleFilter.Name = "txtBundleFilter";
+      this.txtBundleFilter.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+      this.txtBundleFilter.Size = new System.Drawing.Size(604, 128);
+      this.txtBundleFilter.TabIndex = 4;
+      // 
+      // lblBundleFilter
+      // 
+      this.lblBundleFilter.AutoSize = true;
+      this.lblBundleFilter.Location = new System.Drawing.Point(18, 113);
+      this.lblBundleFilter.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblBundleFilter.Name = "lblBundleFilter";
+      this.lblBundleFilter.Size = new System.Drawing.Size(98, 20);
+      this.lblBundleFilter.TabIndex = 3;
+      this.lblBundleFilter.Text = "Bundle Filter";
+      // 
+      // lblBundleFilterDescription
+      // 
+      this.lblBundleFilterDescription.AutoSize = true;
+      this.lblBundleFilterDescription.Location = new System.Drawing.Point(122, 254);
+      this.lblBundleFilterDescription.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.lblBundleFilterDescription.Name = "lblBundleFilterDescription";
+      this.lblBundleFilterDescription.Size = new System.Drawing.Size(528, 20);
+      this.lblBundleFilterDescription.TabIndex = 5;
+      this.lblBundleFilterDescription.Text = "List of OSGi bundle symbolic names to be ignored on bundle status check";
+      // 
       // PreferencesDialog
-      //
-      this.AcceptButton = this.cmOK;
-      this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+      // 
+      this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
       this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
       this.CancelButton = this.cmdCancel;
-      this.ClientSize = new System.Drawing.Size(614, 77);
-      this.Controls.Add(this.label1);
+      this.ClientSize = new System.Drawing.Size(921, 300);
+      this.Controls.Add(this.lblBundleFilterDescription);
+      this.Controls.Add(this.txtBundleFilter);
+      this.Controls.Add(this.lblBundleFilter);
+      this.Controls.Add(this.lblLogViewerDescription);
       this.Controls.Add(this.txtLogViewer);
       this.Controls.Add(this.lblLogViewer);
       this.Controls.Add(this.cmdCancel);
-      this.Controls.Add(this.cmOK);
+      this.Controls.Add(this.cmdOK);
       this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+      this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
       this.MaximizeBox = false;
       this.MinimizeBox = false;
       this.Name = "PreferencesDialog";
@@ -104,9 +145,12 @@ namespace AEMManager {
     #endregion
 
     private System.Windows.Forms.Button cmdCancel;
-    private System.Windows.Forms.Button cmOK;
+    private System.Windows.Forms.Button cmdOK;
     private System.Windows.Forms.TextBox txtLogViewer;
     private System.Windows.Forms.Label lblLogViewer;
-    private System.Windows.Forms.Label label1;
+    private System.Windows.Forms.Label lblLogViewerDescription;
+    private System.Windows.Forms.TextBox txtBundleFilter;
+    private System.Windows.Forms.Label lblBundleFilter;
+    private System.Windows.Forms.Label lblBundleFilterDescription;
   }
 }

--- a/AEMManager/PreferencesDialog.cs
+++ b/AEMManager/PreferencesDialog.cs
@@ -1,9 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
 using System.Windows.Forms;
 using Microsoft.Win32;
 using AEMManager.Util;
@@ -19,12 +14,14 @@ namespace AEMManager {
     private void PreferencesDialog_Load(object sender, EventArgs e) {
       RegistryKey preferencesKey = RegistryUtil.GetUserKey("Preferences");
       txtLogViewer.Text = (string)preferencesKey.GetValue("LogViewer", "notepad.exe");
+      txtBundleFilter.Text = (string)preferencesKey.GetValue("BundleFilter", "");
     }
 
-    private void cmOK_Click(object sender, EventArgs e) {
+    private void cmdOK_Click(object sender, EventArgs e) {
 
       RegistryKey preferencesKey = RegistryUtil.GetUserKey("Preferences");
       preferencesKey.SetValue("LogViewer", txtLogViewer.Text);
+      preferencesKey.SetValue("BundleFilter", txtBundleFilter.Text);
 
       this.DialogResult = DialogResult.OK;
       this.Close();

--- a/AEMManager/PreferencesDialog.resx
+++ b/AEMManager/PreferencesDialog.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>


### PR DESCRIPTION
Sometimes, you want bundles like `aem-precompiled-scripts` excluded form bundles status check, as they are stopped on purpose.
Allow to configure a list of ignored bundle symbolic IDs in the preferences dialog.