### PR TITLE
Support running AEM instances on WSL

### DIFF
--- a/AEMManager/AemActions.cs
+++ b/AEMManager/AemActions.cs
@@ -313,9 +313,11 @@ namespace AEMManager {
       }
     }
 
-    /**
-     * Detects if the given path points to WSL and strips of the WSL path prefix.
-     */
+    /// <summary>
+    /// Detects if the given path points to WSL and returns the related Unix path if that's the case.
+    /// </summary>
+    /// <param name="path">The path to check.</param>
+    /// <returns>The Unix path if a WSL path is detected, or null if no WSL path is detected.</returns>
     private static string GetWslPath(string path) {
       Regex regex = new Regex(@"^\\\\wsl.localhost\\[^\\\s]+(\\[^\s]+)$");
       Match match = regex.Match(path.Trim());


### PR DESCRIPTION
If you use an instance path like
```
\\wsl.localhost\Ubuntu\home\myuser\dev\aem\aem-sdk_test\author\aem-sdk-quickstart-2025.3.19823.20250304T101418Z-250200.jar
```
this is detected automatically, and the instance is started via `wsl` command instead of directly.

make sure to use a linux path or just `java` for "Java Exec".